### PR TITLE
Added build/install/install-deps targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,14 @@ clean:
 	@find . -name '*.pyc' -exec rm -f {} +
 	@find . -name '*.pyo' -exec rm -f {} +
 
+.PHONY: build
+build:
+	true
+
+.PHONY: install-deps
+install-deps:
+	pip install -r requirements.txt
+
 .PHONY: install
 install:
 	python setup.py install

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     author_email='leapp-devel@redhat.com',
     license="GPLv2+",
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
-    install_requires=['click', 'requests'],
+    install_requires=[],
     entry_points={
         'console_scripts': [
             'leappctl=leappctl.cli:main',


### PR DESCRIPTION
Adding targets into makefile

build - just plain true, since there is nothing to build, but we will have common targets in all projects.
install-deps - will install all build & runtime dependencies
install - will install the snactor project